### PR TITLE
[feat] add oauth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@
  * Server index file to define servable routes
  * route-specific functions inside of lib/requestHelper.js
  */
-
+require("dotenv").config();
 const express = require('express');
+const request = require('request');
 const bodyParser = require('body-parser');
 const util = require('./lib/requestHelper');
 const app = express();
@@ -11,9 +12,45 @@ const PORT = process.env.PORT || 3000;
 
 app.use(express.static(`${__dirname}/public`));
 
-app.use(bodyParser.urlencoded({ extended: false }))
-app.use(bodyParser.json())
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
 
+// testing slack auth
+app.get('/slackauth', (req, res) => {
+  const url = `https://slack.com/oauth/authorize?client_id=${process.env.CLIENT_ID}&scope=chat:write:bot&redirect_uri=${process.env.REDIRECT_URI}`;
+  res.redirect(url);
+});
+
+// app.get('/oauthsuccess', (req, res) => {
+
+// })
+app.get("/auth/redirect", (req, res) => {
+  var options = {
+    uri:
+      "https://slack.com/api/oauth.access?code=" +
+      req.query.code +
+      "&client_id=" +
+      process.env.CLIENT_ID +
+      "&client_secret=" +
+      process.env.CLIENT_SECRET +
+      "&redirect_uri=" +
+      process.env.REDIRECT_URI,
+    method: "GET"
+  };
+  request(options, (error, response, body) => {
+    var JSONresponse = JSON.parse(body);
+    if (!JSONresponse.ok) {
+      console.log(JSONresponse);
+      res
+        .send("Error encountered: \n" + JSON.stringify(JSONresponse))
+        .status(200)
+        .end();
+    } else {
+      console.log(JSONresponse);
+      res.send("Success!");
+    }
+  });
+});
 // testing request helper
 app.get('/home', util.getHome);
 

--- a/lib/requestHelper.js
+++ b/lib/requestHelper.js
@@ -33,6 +33,8 @@ module.exports = {
   }
 } 
 
+// db.saveOAuth
+
 // testing database
 // exports.getUsers 
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   "homepage": "https://github.com/phailsafe/shush#readme",
   "dependencies": {
     "body-parser": "^1.18.2",
+    "dotenv": "^4.0.0",
     "express": "^4.16.2",
     "mysql2": "^1.5.1",
     "nodemon": "^1.14.3",
+    "request": "^2.83.0",
     "sequelize": "^4.28.6"
-
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -15,6 +15,6 @@
     <!--[if lt IE 7]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="#">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
-    
+    <a href="/slackauth">Authenticate Slack</a>
   </body>
 </html>


### PR DESCRIPTION
Got basic OAuth handshake working: a user is able to go to the OAuth page and give access, then the app gets a message from Slack with a code and sends another request to Slack to get the full OAuth credentials. Can't yet store said credentials in database because of some mySQL2 weirdness.